### PR TITLE
runs: show command log when return_code is not 0

### DIFF
--- a/balto/runners/base.py
+++ b/balto/runners/base.py
@@ -71,6 +71,7 @@ class BaseRunner:
         self.collect_only = collect_only
         self.suite_name = suite_name
         self.run_id = uuid.uuid4().hex
+        self.extra_lines = []
 
     @property
     def command(self):
@@ -90,3 +91,11 @@ class BaseRunner:
             data["run_id"] = self.run_id
 
             await self.event_emitter.emit(data)
+        elif line.strip():
+            # Decode bytes if we get bytes
+            if hasattr(line, "decode"):
+                decodedline = line.decode("utf-8")
+            else:
+                decodedline = line
+
+            self.extra_lines.append(decodedline)

--- a/balto/runners/subprocess_runner.py
+++ b/balto/runners/subprocess_runner.py
@@ -83,7 +83,7 @@ class SubprocessRunnerSession(BaseRunner):
             LOGGER.warning("CMD %r exited with return code: %d", cmd, return_code)
 
         await self.event_emitter.emit(
-            {"_type": "run_stop", "run_id": self.run_id, "return_code": return_code}
+            {"_type": "run_stop", "run_id": self.run_id, "return_code": return_code, "return_message": ''.join(self.extra_lines) }
         )
 
         return return_code

--- a/balto/web_interfaces/balto_react/src/components/RunsList.js
+++ b/balto/web_interfaces/balto_react/src/components/RunsList.js
@@ -1,10 +1,66 @@
-import React from "react";
+import _ from "lodash";
 import PropTypes from "prop-types";
+import React from "react";
+import { Card, Modal, Section } from "react-bulma-components";
 import { Message, Progress } from "react-bulma-components/full";
 import Moment from "react-moment";
+
 import { convert } from "../time";
-import { Card } from "react-bulma-components";
-import _ from "lodash";
+
+class ReturnCode extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      show_message: false,
+    };
+    this.handleOpen = this.handleOpen.bind(this);
+    this.handleClose = this.handleClose.bind(this);
+  }
+
+  handleOpen() {
+    this.setState({ show_message: true });
+  }
+
+  handleClose() {
+    this.setState({ show_message: false });
+  }
+
+  render() {
+    const { return_code, return_message } = this.props;
+    return (
+      <React.Fragment>
+        <span style={{ color: "red", cursor: "pointer" }} onClick={this.handleOpen}>
+          [{return_code}]
+        </span>
+        <Modal
+          closeOnBlur={true}
+          show={this.state.show_message}
+          showClose={false}
+          onClose={this.handleClose}
+        >
+          <Modal.Content style={{ display: 'flex', width: '90%' }}>
+            <Section style={{
+              backgroundColor: 'white',
+              color: 'black',
+              flexGrow: '1',
+              fontFamily: 'monospace',
+              fontSize: '0.8em',
+              overflow: 'auto',
+              whiteSpace: 'pre',
+            }}>
+              {return_message}
+            </Section>
+          </Modal.Content>
+        </Modal>
+      </React.Fragment>
+    );
+  }
+}
+
+ReturnCode.propTypes = {
+  return_code: PropTypes.number,
+  return_message: PropTypes.string,
+};
 
 export const RunDetails = ({
   date_started,
@@ -13,6 +69,7 @@ export const RunDetails = ({
   done,
   test_number,
   return_code,
+  return_message,
   total_duration
 }) => {
   let header = [
@@ -32,7 +89,7 @@ export const RunDetails = ({
     );
 
     if (return_code !== undefined && return_code !== 0) {
-      header.push(<span style={{ color: "red" }}>[{return_code}]</span>);
+      header.push(<ReturnCode return_code={return_code} return_message={return_message} />);
     }
   }
 
@@ -64,6 +121,7 @@ RunDetails.propTypes = {
   done: PropTypes.number,
   test_number: PropTypes.number,
   return_code: PropTypes.number,
+  return_message: PropTypes.string,
   total_duration: PropTypes.number
 };
 
@@ -84,6 +142,7 @@ export class RunsList extends React.Component {
           test_number={run.test_number}
           done={run.done}
           return_code={run.return_code}
+          return_message={run.return_message}
           total_duration={run.total_duration}
         />
       );

--- a/balto/web_interfaces/balto_react/src/state.js
+++ b/balto/web_interfaces/balto_react/src/state.js
@@ -159,7 +159,8 @@ class TestContainer extends Container<TestState> {
               [run_id]: {
                 ...run,
                 status: "finished",
-                return_code: msg.return_code
+                return_code: msg.return_code,
+                return_message: msg.return_message,
               }
             };
             return {


### PR DESCRIPTION
The return code was displayed in the run result when it was not null.
However, the reason of this code was not available in the UI.

This patch collects non LITF-parsable lines and send them to the client
along with the return_code.
The React client still displays the return code in the run result, and
when clicked it shows a modal dialog containing these collected lines.