### PR TITLE
makefile: add a rule to perform a yarn install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ clean:
 	rm -Rf dist/ build/
 	rm -Rf balto/web_interfaces/balto_react/build/
 
-build_react: clean
+build_react: clean balto/web_interfaces/balto_react/node_modules
 	cd balto/web_interfaces/balto_react/ && yarn build
 
 build_app: clean
@@ -15,3 +15,6 @@ develop: build_react build_app
 
 publish:
 	poetry publish
+
+balto/web_interfaces/balto_react/node_modules:
+	cd balto/web_interfaces/balto_react/ && yarn install


### PR DESCRIPTION
When I see a Makefile, I just want to run `make` and everything to set up itself.

This rule will run `yarn install` if needed, in order to create and populate the `balto/web_interfaces/balto_react/node_modules` folder.